### PR TITLE
fixing explicit coma in json's structure of readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ For automation purposes, you can provide necessary data before to be prompted fo
   "caproverRootDomain": "root.domain.com",
   "newPassword": "rAnDoMpAsSwOrD",
   "certificateEmail": "email@gmail.com",
-  "caproverName": "my-machine-123-123-123-123",
+  "caproverName": "my-machine-123-123-123-123"
 }
 ```
 And then running:


### PR DESCRIPTION
Fixing `Error reading config file: Unexpected token } in JSON at position 256` error in example JSON file