### PR TITLE
New parameter -s to diferente "captain" sub-domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .idea
 npm-debug.log
 .DS_Store
+.vscode

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -56,8 +56,18 @@ export default class Api extends Command {
             type: 'input',
             message: `CapRover machine URL address, it is "[http[s]://][${Constants.ADMIN_DOMAIN}.]your-captain-root.domain"`,
             when: false,
-            filter: (url: string) => Utils.cleanAdminDomainUrl(url) || url, // If not cleaned url, leave url to fail validation with correct error
-            validate: (url: string) => getErrorForDomain(url, true)
+            filter: (url: string) =>
+                Utils.cleanAdminDomainUrl(
+                    url,
+                    undefined,
+                    this.paramValue(params, K.captainSubDomain)
+                ) || url, // If not cleaned url, leave url to fail validation with correct error
+            validate: (url: string) =>
+                getErrorForDomain(
+                    url,
+                    true,
+                    this.paramValue(params, K.captainSubDomain)
+                )
         },
         {
             name: K.pwd,
@@ -103,7 +113,8 @@ export default class Api extends Command {
                         true
                     )
                 }
-            }
+            },
+            this.paramValue(params, K.captainSubDomain)
         ),
         {
             name: K.path,
@@ -200,6 +211,14 @@ export default class Api extends Command {
                 this.paramFrom(params, K.data) === ParamType.Question,
             preProcessParam: (param: IParam) =>
                 param && userCancelOperation(!param.value)
+        },
+        {
+            name: K.captainSubDomain,
+            char: 's',
+            env: 'CAPTAIN_SUB_DOMAIN',
+            message: 'captain sub-domain',
+            type: 'input',
+            when: false
         }
     ]
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -36,7 +36,8 @@ const K = Utils.extendCommonKeys({
     branch: 'branch',
     tar: 'tarFile',
     appToken: 'appToken',
-    img: 'imageName'
+    img: 'imageName',
+    captainSubDomain: 'captainSubDomain'
 })
 
 export default class Deploy extends Command {
@@ -81,8 +82,18 @@ export default class Deploy extends Command {
             type: 'input',
             message: `CapRover machine URL address, it is "[http[s]://][${Constants.ADMIN_DOMAIN}.]your-captain-root.domain"`,
             when: false,
-            filter: (url: string) => Utils.cleanAdminDomainUrl(url) || url, // If not cleaned url, leave url to fail validation with correct error
-            validate: (url: string) => getErrorForDomain(url, true)
+            filter: (url: string) =>
+                Utils.cleanAdminDomainUrl(
+                    url,
+                    undefined,
+                    this.paramValue(params, K.captainSubDomain)
+                ) || url, // If not cleaned url, leave url to fail validation with correct error
+            validate: (url: string) =>
+                getErrorForDomain(
+                    url,
+                    true,
+                    this.paramValue(params, K.captainSubDomain)
+                )
         },
         {
             name: K.pwd,
@@ -138,7 +149,8 @@ export default class Deploy extends Command {
                         true
                     )
                 }
-            }
+            },
+            this.paramValue(params, K.captainSubDomain)
         ),
         {
             name: K.app,
@@ -199,6 +211,14 @@ export default class Deploy extends Command {
             char: 't',
             env: 'CAPROVER_APP_TOKEN',
             message: 'app Token',
+            type: 'input',
+            when: false
+        },
+        {
+            name: K.captainSubDomain,
+            char: 's',
+            env: 'CAPTAIN_SUB_DOMAIN',
+            message: 'captain sub-domain',
             type: 'input',
             when: false
         },
@@ -307,7 +327,8 @@ export default class Deploy extends Command {
                                 }
                                 this.validateDeploySource(params)
                             }
-                        }
+                        },
+                        this.paramValue(params, K.captainSubDomain)
                     )
                 ]
                 return Promise.resolve({})

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -38,9 +38,15 @@ export default class Login extends Command {
             filter: (url: string) =>
                 Utils.cleanAdminDomainUrl(
                     url,
-                    this.paramValue(params, K.https)
+                    this.paramValue(params, K.https),
+                    this.paramValue(params, K.captainSubDomain)
                 ) || url, // If not cleaned url, leave url to fail validation with correct error
-            validate: (url: string) => getErrorForDomain(url)
+            validate: (url: string) =>
+                getErrorForDomain(
+                    url,
+                    undefined,
+                    this.paramValue(params, K.captainSubDomain)
+                )
         },
         {
             name: K.pwd,
@@ -60,6 +66,14 @@ export default class Login extends Command {
             default: params && CliHelper.get().findDefaultCaptainName(),
             filter: (name: string) => name.trim(),
             validate: (name: string) => getErrorForMachineName(name)
+        },
+        {
+            name: K.captainSubDomain,
+            char: 's',
+            env: 'CAPTAIN_SUB_DOMAIN',
+            message: 'captain sub-domain',
+            type: 'input',
+            when: false
         }
     ]
 

--- a/src/commands/serversetup.ts
+++ b/src/commands/serversetup.ts
@@ -162,7 +162,8 @@ export default class ServerSetup extends Command {
             preProcessParam: (param: IParam) =>
                 this.enableSslAndChangePassword(
                     param.value,
-                    this.paramValue(params, K.newPwd)
+                    this.paramValue(params, K.newPwd),
+                    this.paramValue(params, K.captainSubDomain)
                 )
         },
         {
@@ -178,6 +179,14 @@ export default class ServerSetup extends Command {
             validate: (name: string) => getErrorForMachineName(name),
             preProcessParam: (param?: IParam) =>
                 param && (this.machine.name = param.value)
+        },
+        {
+            name: K.captainSubDomain,
+            char: 's',
+            env: 'CAPTAIN_SUB_DOMAIN',
+            message: 'captain sub-domain',
+            type: 'input',
+            when: false
         }
     ]
 
@@ -276,7 +285,8 @@ export default class ServerSetup extends Command {
 
     private async enableSslAndChangePassword(
         email: string,
-        newPassword?: string
+        newPassword?: string,
+        captainSubDomain?: string
     ) {
         let forcedSsl = false
         try {
@@ -285,7 +295,8 @@ export default class ServerSetup extends Command {
             await CliApiManager.get(this.machine).enableRootSsl(email)
             this.machine.baseUrl = Utils.cleanAdminDomainUrl(
                 this.machine.baseUrl,
-                true
+                true,
+                captainSubDomain
             )!
             await CliApiManager.get(this.machine).forceSsl(true)
             forcedSsl = true

--- a/src/utils/CliHelper.ts
+++ b/src/utils/CliHelper.ts
@@ -123,14 +123,15 @@ export default class CliHelper {
     async ensureAuthentication(
         url?: string,
         password?: string,
-        machineName?: string
+        machineName?: string,
+        captainSubDomain?: string
     ): Promise<IMachine> {
         if (url) {
             // Auth to url
             const machine: IMachine = { baseUrl: url, name: '', authToken: '' }
             if (machineName) {
                 // With machine name: also store credentials
-                let err = getErrorForDomain(url)
+                let err = getErrorForDomain(url, undefined, captainSubDomain)
                 if (err !== true) {
                     // Error for domain: can't store credentials
                     StdOutUtil.printWarning(
@@ -186,7 +187,8 @@ export default class CliHelper {
         url?: string | (() => string | undefined),
         password?: string | (() => string | undefined),
         name?: string | (() => string | undefined),
-        done?: (machine: IMachine) => void
+        done?: (machine: IMachine) => void,
+        captainSubDomain?: string
     ): IOption {
         let machine: IMachine
         return {
@@ -221,7 +223,8 @@ export default class CliHelper {
                     machine = await CliHelper.get().ensureAuthentication(
                         urlExtracted,
                         passwordExtracted,
-                        nameExtracted
+                        nameExtracted,
+                        captainSubDomain
                     )
                     return !machine.authToken
                 } catch (e) {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -23,6 +23,7 @@ export default {
         url: 'caproverUrl',
         pwd: 'caproverPassword',
         name: 'caproverName',
-        app: 'caproverApp'
+        app: 'caproverApp',
+        captainSubDomain: 'captainSubDomain'
     }
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -42,13 +42,17 @@ const util = {
             if (!u.protocol) {
                 u = url.parse(`//${urlInput}`, false, true)
             }
-            return u.hostname
+            return u.hostname ?? undefined
         } catch (e) {
             return undefined
         }
     },
 
-    cleanAdminDomainUrl(urlInput: string, https?: boolean): string | undefined {
+    cleanAdminDomainUrl(
+        urlInput: string,
+        https?: boolean,
+        captainSubDomain?: string
+    ): string | undefined {
         if (!urlInput || !urlInput.length) {
             return undefined
         }
@@ -57,8 +61,14 @@ const util = {
         if (!cleanedUrl) {
             return undefined
         }
-        if (!cleanedUrl.startsWith(`${ADMIN_DOMAIN}.`)) {
-            cleanedUrl = `${ADMIN_DOMAIN}.${cleanedUrl}`
+        if (!!captainSubDomain) {
+            if (!cleanedUrl.startsWith(`${captainSubDomain}.`)) {
+                cleanedUrl = `${captainSubDomain}.${cleanedUrl}`
+            }
+        } else {
+            if (!cleanedUrl.startsWith(`${ADMIN_DOMAIN}.`)) {
+                cleanedUrl = `${ADMIN_DOMAIN}.${cleanedUrl}`
+            }
         }
         return (
             (https || (https === undefined && !http) ? 'https://' : 'http://') +

--- a/src/utils/ValidationsHandler.ts
+++ b/src/utils/ValidationsHandler.ts
@@ -77,12 +77,17 @@ export function getErrorForIP(value: string): true | string {
 
 export function getErrorForDomain(
     value: string,
-    skipAlreadyStored?: boolean
+    skipAlreadyStored?: boolean,
+    captainSubDomain?: string
 ): true | string {
     if (value === Constants.SAMPLE_DOMAIN) {
         return 'Enter a valid URL.'
     }
-    const cleaned = Utils.cleanAdminDomainUrl(value)
+    const cleaned = Utils.cleanAdminDomainUrl(
+        value,
+        undefined,
+        captainSubDomain
+    )
     if (!cleaned) {
         return `This is an invalid URL: ${StdOutUtil.getColoredMachineUrl(
             value
@@ -93,7 +98,11 @@ export function getErrorForDomain(
             .getMachines()
             .find(
                 machine =>
-                    Utils.cleanAdminDomainUrl(machine.baseUrl) === cleaned
+                    Utils.cleanAdminDomainUrl(
+                        machine.baseUrl,
+                        undefined,
+                        captainSubDomain
+                    ) === cleaned
             )
         if (found) {
             return `${StdOutUtil.getColoredMachineUrl(


### PR DESCRIPTION
Hey guys,

Thank you all for the excellent platform.

I made some adjustments to adapt the cli to the caprover's "captainSubDomain" parameter:
/captain/data/config-override.json
```j́son
{"captainSubDomain":"admin"}
```

The option already exists on the platform but the cli always requires the use of "captain", in my case my captain servers are like "node1", "node2", "node3", etc....

This is bothering me because I can't use the cli in a CI CD environment.

I created an additional parameter -s, example

```sh
npx caprover deploy -h mydomain.com -s node1 -p 123456 -a app-test -i my-image
```
