### PR TITLE
Create variable to override captain sub-domain

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,4 +1,4 @@
-const ADMIN_DOMAIN = 'captain'
+const ADMIN_DOMAIN = process.env.CAPROVER_ADMIN_DOMAIN_OVERRIDE ?? 'captain'
 const SAMPLE_DOMAIN = `${ADMIN_DOMAIN}.captainroot.yourdomain.com`
 const SAMPLE_IP = '123.123.123.123'
 const DEFAULT_PASSWORD = 'captain42'

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,4 +1,4 @@
-const ADMIN_DOMAIN = process.env.CAPROVER_ADMIN_DOMAIN_OVERRIDE ?? 'captain'
+const ADMIN_DOMAIN = process.env.CAPROVER_ADMIN_DOMAIN_OVERRIDE || 'captain'
 const SAMPLE_DOMAIN = `${ADMIN_DOMAIN}.captainroot.yourdomain.com`
 const SAMPLE_IP = '123.123.123.123'
 const DEFAULT_PASSWORD = 'captain42'

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -42,7 +42,7 @@ const util = {
             if (!u.protocol) {
                 u = url.parse(`//${urlInput}`, false, true)
             }
-            return u.hostname ?? undefined
+            return u.hostname || undefined
         } catch (e) {
             return undefined
         }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -42,7 +42,7 @@ const util = {
             if (!u.protocol) {
                 u = url.parse(`//${urlInput}`, false, true)
             }
-            return u.hostname
+            return u.hostname ?? undefined
         } catch (e) {
             return undefined
         }


### PR DESCRIPTION
Hi

Adaptation of the cli for the existing configuration of caprover in the file "/captain/data/config-override.json":
```json
{"captainSubDomain":"my_domain"}
```
Created new variable "CAPROVER_ADMIN_DOMAIN_OVERRIDE"

Suggested by @githubsaturn in PR #113