### PR TITLE
fix: typo on credentials

### DIFF
--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -38,7 +38,7 @@ export default class Api extends Command {
         '       api [-c file] [-n name] [-t path] [-m method] [-d dataJsonString]\n' +
         '       api [-c file] -u url [-p password] [-n name] [-t path] [-m method] [-d dataJsonString]\n' +
         '  Use --caproverName to use an already logged in CapRover machine\n' +
-        '  Use --caproverUrl and --caproverPassword to login on the fly to a CapRover machine, if also --caproverName is present, login credetials are stored locally'
+        '  Use --caproverUrl and --caproverPassword to login on the fly to a CapRover machine, if also --caproverName is present, login credentials are stored locally'
 
     protected description =
         'Call a generic API on a specific CapRover machine. Use carefully only if you really know what you are doing!'

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -49,7 +49,7 @@ export default class Deploy extends Command {
         '       deploy [-c file] [-n name] [-a app] [-b branch | -t tarFile | -i image]\n' +
         '       deploy [-c file] -u url [-p password] [-n name] [-a app] [-b branch | -t tarFile | -i image]\n' +
         '  Use --caproverName to use an already logged in CapRover machine\n' +
-        '  Use --caproverUrl and --caproverPassword to login on the fly to a CapRover machine, if also --caproverName is present, login credetials are stored locally\n' +
+        '  Use --caproverUrl and --caproverPassword to login on the fly to a CapRover machine, if also --caproverName is present, login credentials are stored locally\n' +
         '  Use one among --branch, --tarFile, --imageName'
 
     protected description =


### PR DESCRIPTION
The typo was displayed by the CLI:

```bash
$ caprover deploy --help | grep credetials
  […] login credetials are stored locally
```