### PR TITLE
Fix duplicate deploy option shorthand

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -196,7 +196,6 @@ export default class Deploy extends Command {
         },
         {
             name: K.appToken,
-            char: 't',
             env: 'CAPROVER_APP_TOKEN',
             message: 'app Token',
             type: 'input',


### PR DESCRIPTION
## Summary

Fixes #126 by removing the duplicate `-t` shorthand from the `appToken` deploy option.

## Problem

Both `tarFile` and `appToken` register the `-t` shorthand. Newer versions of Commander reject this conflict while initializing the `deploy` command, preventing all deployments from running.

## Changes

- Removed the `-t` shorthand from `appToken`.
- Kept `-t` assigned to `tarFile`.
- `appToken` remains available through `--appToken` and the `CAPROVER_APP_TOKEN` environment variable.

This is a one-line, targeted bug fix with no refactoring or unrelated changes.

## Verification

- `npm run formatter`
- `npm run build`
- Verified that `caprover deploy --help` exits successfully.
- Verified that `-t` maps to `--tarFile`.
- Verified that `--appToken` is still available.

## Checklist

- [x] I have read the contribution guidelines.
- [x] I have communicated the proposed change on the CapRover Slack channel.

Related issue: #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `-t` shorthand for the deployment app token option. The full option name and environment variable remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->