### PR TITLE
Fixes command execution failing with Positional parameter not supported: [object Object]

### DIFF
--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -202,6 +202,8 @@ export default abstract class Command {
         })
 
         cmd.action(async (...allParams: any[]) => {
+            const commanderCommand = allParams.pop() as CommanderStatic
+
             if (allParams.length > 1) {
                 StdOutUtil.printError(
                     `Positional parameter not supported: ${allParams[0]}\n`,
@@ -209,7 +211,7 @@ export default abstract class Command {
                 )
             }
 
-            const cmdLineOptions = await this.preAction(allParams[0])
+            const cmdLineOptions = await this.preAction(commanderCommand.opts())
             const optionAliases: IOptionAliasWithDetails[] = this.getOptions()
                 .filter((opt) => opt && opt.name)
                 .reduce(


### PR DESCRIPTION
**Summary**  
Fixes command execution failing with `Positional parameter not supported: [object Object]` by correctly handling the Commander v12 action callback parameters.

**Problem**  
Commander v12 passes the parsed options object and the `Command` instance to action handlers after any declared positional arguments.

The existing implementation checks the raw callback argument count and mistakenly treats these standard parameters as a positional argument. As a result, normal commands fail before execution and display the parsed options object as `[object Object]`.
<img width="1538" height="359" alt="Screenshot 2026-08-06 at 11 54 33 AM" src="https://github.com/user-attachments/assets/db3119dc-3018-45a8-a1df-f6af0e8cf82d" />

**Changes**  
Extracted the Commander `Command` instance from the action callback arguments.  
Read parsed command-line options using `command.opts()`.  
Preserved the existing validation for actual positional arguments.  
This is a four-line, targeted bug fix with no refactoring or unrelated changes.

**Verification**  
`npm run formatter`  
`npm run build`  
Verified that regular command options are parsed successfully.  
Verified that actual positional arguments are still rejected.

**Checklist**  
- [x] I have read the contribution guidelines.
- [x] I have communicated the proposed change on the CapRover Slack channel.

Related issue: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command action handling by providing action hooks with parsed command options.
  * Preserved existing validation for positional parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->